### PR TITLE
Fix gem version

### DIFF
--- a/lib/gitolite/version.rb
+++ b/lib/gitolite/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Gitolite
-  VERSION = '1.3.0'
+  VERSION = '1.5.0'
 end


### PR DESCRIPTION
Synchronizes the version in the code to the tag.

Fixes `rake build` gem from 1.3.0 to 1.5.0.
Allows to build a deb package with the correct version with gem2deb from the rake-built gem above.

Could the gem get published on rubygems? that would be even easier to make a deb from.